### PR TITLE
Implement Filtering by Navigation Pane Category

### DIFF
--- a/src/main/java/controller/homepage/HomepageController.java
+++ b/src/main/java/controller/homepage/HomepageController.java
@@ -13,6 +13,10 @@ public class HomepageController {
         this.getPostInteractor.getAllPosts(); 
     }
 
+    public void getPostsByCategory(String category) {
+        this.getPostInteractor.getPostsByCategory(category);
+    }
+
     public void switchToLoginView() {
         this.getPostInteractor.switchToPostView();
     }

--- a/src/main/java/daos/DBPostDataAccessObject.java
+++ b/src/main/java/daos/DBPostDataAccessObject.java
@@ -71,21 +71,21 @@ public class DBPostDataAccessObject implements CreatePostDataAccessInterface,
         return new JSONObject(queryOnePostBy(ENTRY_ID, id).toJson());
     }
 
-    // TODO used for filtering posts, not implemented yet
-    // @Override
-    // public List<JSONObject> getPostsByCategory(String category) {
-    //     List<JSONObject> posts = new ArrayList<>();
-    //     MongoCursor<Document> retrievedPosts = this.queryMultiplePostsBy(CATEGORY, category);
+    @Override
+    public List<JSONObject> getPostsByCategory(String category) {
+        List<JSONObject> posts = new ArrayList<>();
+        MongoCursor<Document> retrievedPosts = this.queryMultiplePostsBy(CATEGORY, category);
+        try {
+            while (retrievedPosts.hasNext()) {
+                String jsonStr = retrievedPosts.next().toJson();
+                posts.add(new JSONObject(jsonStr));
+            }
+        } finally {
+            retrievedPosts.close();
+        }
+        return posts;
+    }
 
-    //     try {
-    //         while (retrievedPosts.hasNext()) {
-    //             String jsonStr = retrievedPosts.next().toJson();
-    //             posts.add(new JSONObject(jsonStr));
-    //         }
-    //     } finally {
-    //         retrievedPosts.close();
-    //     }
-    // }
 
     @Override
     public List<JSONObject> getAllPostsByUserID(String userID) {

--- a/src/main/java/use_case/getpost/GetPostDataAccessInterface.java
+++ b/src/main/java/use_case/getpost/GetPostDataAccessInterface.java
@@ -29,4 +29,11 @@ public interface GetPostDataAccessInterface {
      * @return a list of post json data
      */
     List<JSONObject> getAllPosts();
+
+    /**
+     * Retrieve all posts with a specific category.
+     * @return a list of post json data
+     */
+    List<JSONObject> getPostsByCategory(String category);
+
 }

--- a/src/main/java/use_case/getpost/GetPostInputBoundary.java
+++ b/src/main/java/use_case/getpost/GetPostInputBoundary.java
@@ -18,6 +18,8 @@ public interface GetPostInputBoundary {
 
     List<Post> getAllPosts();
 
+    List<Post> getPostsByCategory(String category);
+
     void switchToPostView();
 
     void switchToHomePageView();

--- a/src/main/java/use_case/getpost/GetPostInteractor.java
+++ b/src/main/java/use_case/getpost/GetPostInteractor.java
@@ -66,6 +66,19 @@ public class GetPostInteractor implements GetPostInputBoundary {
     }
 
     @Override
+    public List<Post> getPostsByCategory(String category) {
+        List<JSONObject> postDatas = this.postDB.getPostsByCategory(category);
+        List<Post> posts = new ArrayList<>();
+
+        for (JSONObject postData : postDatas) {
+            posts.add(this.jsonToPost(postData));
+        }
+        final GetPostOutputData retrievedFilteredPostOutputData = new GetPostOutputData(posts);
+        getPostPresenter.prepareSuccessView(retrievedFilteredPostOutputData);
+        return posts;
+    }
+
+    @Override
     public void switchToPostView() {
         getPostPresenter.switchToPostView();
     }
@@ -74,6 +87,7 @@ public class GetPostInteractor implements GetPostInputBoundary {
     public void switchToHomePageView() {
         getPostPresenter.switchToHomePageView();
     }
+
 
     private Post jsonToPost(JSONObject postData) {
         Content postContent = new PostContent(postData.getString("content_body"),

--- a/src/main/java/use_case/getpost/GetPostInteractor.java
+++ b/src/main/java/use_case/getpost/GetPostInteractor.java
@@ -30,7 +30,7 @@ public class GetPostInteractor implements GetPostInputBoundary {
         final String entryID = postInputData.getEntryID();
 
         if (entryID == null) {
-            getPostPresenter.prepareFailView("Unable to retrieve post with entryID: " + entryID);
+            getPostPresenter.prepareFailView("Unable to retrieve post with null entryID");
             return null;
         }
 

--- a/src/main/java/use_case/getpost/GetPostInteractor.java
+++ b/src/main/java/use_case/getpost/GetPostInteractor.java
@@ -1,16 +1,16 @@
 package use_case.getpost;
 
-import entity.Comment;
-import entity.Content;
-import entity.Post;
-import entity.PostContent;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
+import entity.Comment;
+import entity.Content;
+import entity.Post;
+import entity.PostContent;
 
 /**
  * The Get Post Interactor.
@@ -28,8 +28,10 @@ public class GetPostInteractor implements GetPostInputBoundary {
     @Override
     public Post getPost(GetPostInputData postInputData) throws IllegalArgumentException {
         final String entryID = postInputData.getEntryID();
+
         if (entryID == null) {
-            throw new IllegalArgumentException();
+            getPostPresenter.prepareFailView("Unable to retrieve post with entryID: " + entryID);
+            return null;
         }
 
         try {
@@ -45,7 +47,7 @@ public class GetPostInteractor implements GetPostInputBoundary {
             getPostPresenter.prepareSuccessView(retrievedPostOutputData);
             return retrievedPost;
         }
-        catch (Exception ex) {
+        catch (PostNotFoundException ex) {
             getPostPresenter.prepareFailView(ex.getMessage());
             return null;
         }
@@ -53,8 +55,8 @@ public class GetPostInteractor implements GetPostInputBoundary {
 
     @Override
     public List<Post> getAllPosts() {
-        List<JSONObject> postDatas = this.postDB.getAllPosts();
-        List<Post> posts = new ArrayList<>();
+        final List<JSONObject> postDatas = this.postDB.getAllPosts();
+        final List<Post> posts = new ArrayList<>();
 
         for (JSONObject postData : postDatas) {
             posts.add(this.jsonToPost(postData));
@@ -67,8 +69,8 @@ public class GetPostInteractor implements GetPostInputBoundary {
 
     @Override
     public List<Post> getPostsByCategory(String category) {
-        List<JSONObject> postDatas = this.postDB.getPostsByCategory(category);
-        List<Post> posts = new ArrayList<>();
+        final List<JSONObject> postDatas = this.postDB.getPostsByCategory(category);
+        final List<Post> posts = new ArrayList<>();
 
         for (JSONObject postData : postDatas) {
             posts.add(this.jsonToPost(postData));
@@ -88,21 +90,20 @@ public class GetPostInteractor implements GetPostInputBoundary {
         getPostPresenter.switchToHomePageView();
     }
 
-
     private Post jsonToPost(JSONObject postData) {
-        Content postContent = new PostContent(postData.getString("content_body"),
+        final Content postContent = new PostContent(postData.getString("content_body"),
                 postData.getString("attachment_path"),
                 postData.getString("file_type"));
 
-        JSONArray commentData = postData.getJSONArray("comments");
-        List<Comment> comments = new ArrayList<>();
-        for (int i = 0; i < commentData.length(); i++){
+        final JSONArray commentData = postData.getJSONArray("comments");
+        final List<Comment> comments = new ArrayList<>();
+        for (int i = 0; i < commentData.length(); i++) {
             // TODO modify when implementing the comment feature. Will likely need to change the DAO implementation
             // Comment comment = new Comment();
             comments.add(null);
         }
 
-        Post post = new Post(
+        final Post post = new Post(
                 postData.getString("post_id"),
                 postData.getString("author"),
                 postContent,

--- a/src/main/java/use_case/getpost/GetPostOutputData.java
+++ b/src/main/java/use_case/getpost/GetPostOutputData.java
@@ -63,8 +63,9 @@ public class GetPostOutputData {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         GetPostOutputData that = (GetPostOutputData) o;
-        return entryID.equals(that.entryID) &&
-                postContent.equals(that.postContent);
+        //Safely compares for null
+        return Objects.equals(entryID, that.entryID) &&
+                Objects.equals(postContent, that.postContent);
     }
 
     @Override

--- a/src/main/java/use_case/getpost/PostNotFoundException.java
+++ b/src/main/java/use_case/getpost/PostNotFoundException.java
@@ -3,7 +3,7 @@ package use_case.getpost;
 /**
  * Exception thrown when a post cannot be found by its entryID.
  */
-public class PostNotFoundException extends Exception {
+public class PostNotFoundException extends IllegalArgumentException {
     public PostNotFoundException(String entryID) {
         super("Post with entryID " + entryID + " not found.");
     }

--- a/src/main/java/view/HomePageView.java
+++ b/src/main/java/view/HomePageView.java
@@ -107,6 +107,8 @@ public class HomePageView extends JPanel implements PropertyChangeListener {
                 post.getPostTitle(), post.getContent().getBody(), 
                 post.getEntryID(), homepage, homepageController, postController).getPostBox());
         }
+        revalidate();
+        repaint();
     }
     // For testing purposes
     private void addDummyPost() {

--- a/src/main/java/view/HomePageView.java
+++ b/src/main/java/view/HomePageView.java
@@ -42,8 +42,7 @@ public class HomePageView extends JPanel implements PropertyChangeListener {
         mainContent.add(navBar, BorderLayout.NORTH);
 
         // Add navigation pane
-        final JPanel navigationPanel = NavigationPane.createNavigationPane(homepage);
-        homepage.add(navigationPanel, BorderLayout.WEST);
+        final JPanel navigationPanel = new NavigationPane(homepage, this.homepageViewModel, this.homepageController).getNavigationPane();        homepage.add(navigationPanel, BorderLayout.WEST);
 
         // Add center panel to display post previews
         this.contentArea.setLayout(new BoxLayout(contentArea, BoxLayout.Y_AXIS));

--- a/src/main/java/view/NavigationPane.java
+++ b/src/main/java/view/NavigationPane.java
@@ -2,8 +2,6 @@ package view;
 
 import controller.homepage.HomepageController;
 import controller.homepage.HomepageViewModel;
-import entity.Post;
-import use_case.getpost.GetPostInteractor;
 
 import javax.swing.*;
 import java.awt.*;
@@ -33,16 +31,17 @@ public class NavigationPane {
 
         JButton[] categoryButtons = {
                 new JButton("All Posts"),
-                new JButton("Category 1"),
+                new JButton("java"),
                 new JButton("Category 2"),
                 new JButton("Category 3")
         };
         for (JButton button : categoryButtons) {
-//            button.addActionListener(e -> {
-//                String category = button.getText(); // Map button text to actual category if needed
-//                List<> filteredPosts = GetPostInteractor.getPostsByCategory(category);
-//                    // Update the UI to display `filteredPosts`
-//                });
+            button.addActionListener(e -> {
+                String category = button.getText(); // Map button text to actual category if needed
+                System.out.println(category);
+                homepageController.getPostsByCategory(category);
+                homepageController.switchToHomePageView();
+                });
             button.setBackground(StyleConstants.BUTTON_COLOR);
             button.setForeground(StyleConstants.TEXT_COLOR);
             button.setFocusPainted(false);

--- a/src/main/java/view/NavigationPane.java
+++ b/src/main/java/view/NavigationPane.java
@@ -31,17 +31,24 @@ public class NavigationPane {
 
         JButton[] categoryButtons = {
                 new JButton("All Posts"),
-                new JButton("java"),
+                new JButton("Java"),
                 new JButton("Category 2"),
                 new JButton("Category 3")
         };
         for (JButton button : categoryButtons) {
-            button.addActionListener(e -> {
-                String category = button.getText(); // Map button text to actual category if needed
-                System.out.println(category);
-                homepageController.getPostsByCategory(category);
-                homepageController.switchToHomePageView();
+            if (button.getText().equals("All Posts")) {
+                button.addActionListener(e -> {
+                    homepageController.fetchAllPosts();
+                    homepageController.switchToHomePageView();
                 });
+            } else {
+                button.addActionListener(e -> {
+                    String category = button.getText();
+                    System.out.println(category);
+                    homepageController.getPostsByCategory(category);
+                    homepageController.switchToHomePageView();
+                });
+            }
             button.setBackground(StyleConstants.BUTTON_COLOR);
             button.setForeground(StyleConstants.TEXT_COLOR);
             button.setFocusPainted(false);

--- a/src/main/java/view/NavigationPane.java
+++ b/src/main/java/view/NavigationPane.java
@@ -1,5 +1,10 @@
 package view;
 
+import controller.homepage.HomepageController;
+import controller.homepage.HomepageViewModel;
+import entity.Post;
+import use_case.getpost.GetPostInteractor;
+
 import javax.swing.*;
 import java.awt.*;
 
@@ -7,7 +12,19 @@ import java.awt.*;
  * The Navigation Pane
  */
 public class NavigationPane {
-    public static JPanel createNavigationPane(JPanel homepage) {
+
+    private final JPanel navigationPane;
+    private final HomepageViewModel homePageViewModel;
+    private final HomepageController homepageController;
+
+    public NavigationPane(JPanel mainContent, HomepageViewModel homePageViewModel,
+                          HomepageController homepageController) {
+        this.navigationPane = createNavigationPane(mainContent);
+        this.homePageViewModel = homePageViewModel;
+        this.homepageController = homepageController;
+    }
+
+    private JPanel createNavigationPane(JPanel homepage) {
         final JPanel navigationPanel = new JPanel();
         navigationPanel.setBackground(StyleConstants.PANEL_COLOR);
         navigationPanel.setLayout(new BoxLayout(navigationPanel, BoxLayout.Y_AXIS));
@@ -21,6 +38,11 @@ public class NavigationPane {
                 new JButton("Category 3")
         };
         for (JButton button : categoryButtons) {
+//            button.addActionListener(e -> {
+//                String category = button.getText(); // Map button text to actual category if needed
+//                List<> filteredPosts = GetPostInteractor.getPostsByCategory(category);
+//                    // Update the UI to display `filteredPosts`
+//                });
             button.setBackground(StyleConstants.BUTTON_COLOR);
             button.setForeground(StyleConstants.TEXT_COLOR);
             button.setFocusPainted(false);
@@ -30,5 +52,9 @@ public class NavigationPane {
         }
 
         return navigationPanel;
+    }
+
+    public JPanel getNavigationPane() {
+        return this.navigationPane;
     }
 }

--- a/src/test/java/use_case/getpost/GetPostInteractorTest.java
+++ b/src/test/java/use_case/getpost/GetPostInteractorTest.java
@@ -2,6 +2,7 @@ package use_case.getpost;
 
 import entity.*;
 import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,9 +10,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -97,8 +96,12 @@ class GetPostInteractorTest {
     @Test
     void GetPostInvalidInputTest() {
         GetPostInputData inputData = new GetPostInputData(null);
+        String expectedErrorMessage = "Unable to retrieve post with entryID: null";
 
-        assertThrows(IllegalArgumentException.class, () -> interactor.getPost(inputData));
+        Post result = interactor.getPost(inputData);
+
+        assertNull(result, "Result should be null when entryID is invalid.");
+        verify(mockPresenter).prepareFailView(expectedErrorMessage);
     }
 
     @Test
@@ -145,6 +148,163 @@ class GetPostInteractorTest {
 
         verify(mockPresenter).prepareSuccessView(captor.capture());
         assertEquals(expectedOutputData, captor.getValue());
+    }
+
+
+    @Test
+    void GetAllPostsSuccessTest() throws Exception {
+        // Prepare mock data
+        String entryID1 = "123";
+        String entryID2 = "456";
+        String author = "Author1";
+        String contentBody = "Content of post.";
+        String attachmentPath = "path/to/attachment";
+        String fileType = "text/plain";
+        String title = "Post 1";
+        String category = "General";
+        LocalDateTime postedDate = LocalDateTime.now().withNano(0);
+        LocalDateTime lastModified = LocalDateTime.now().withNano(0);
+        int likes = 5;
+        int dislikes = 2;
+        List<Comment> comments = new ArrayList<>();
+
+        // JSON responses from mock database
+        JSONObject postJSON1 = new JSONObject();
+        postJSON1.put("post_id", entryID1);
+        postJSON1.put("author", author);
+        postJSON1.put("content_body", contentBody);
+        postJSON1.put("attachment_path", attachmentPath);
+        postJSON1.put("file_type", fileType);
+        postJSON1.put("title", title);
+        postJSON1.put("category", category);
+        postJSON1.put("posted_date", postedDate.toString());
+        postJSON1.put("last_modified", lastModified.toString());
+        postJSON1.put("likes", likes);
+        postJSON1.put("dislikes", dislikes);
+        postJSON1.put("comments", new JSONArray());
+
+        JSONObject postJSON2 = new JSONObject(convertJsonToMap(postJSON1));
+        postJSON2.put("post_id", entryID2); // Different ID for the second post
+
+        List<JSONObject> postList = new ArrayList<>();
+        postList.add(postJSON1);
+        postList.add(postJSON2);
+
+        when(mockPostDB.getAllPosts()).thenReturn(postList);
+
+        // Define expected outputs
+        Content expectedContent1 = new PostContent(contentBody, attachmentPath, fileType);
+        Content expectedContent2 = new PostContent(contentBody, attachmentPath, fileType);
+
+        Post expectedPost1 = new Post(entryID1, author, expectedContent1, postedDate, lastModified, likes, dislikes, title, comments, category);
+        Post expectedPost2 = new Post(entryID2, author, expectedContent2, postedDate, lastModified, likes, dislikes, title, comments, category);
+
+        List<Post> expectedPosts = new ArrayList<>();
+        expectedPosts.add(expectedPost1);
+        expectedPosts.add(expectedPost2);
+
+        GetPostOutputData expectedOutputData = new GetPostOutputData(expectedPosts);
+
+        // Call the interactor
+        List<Post> result = interactor.getAllPosts();
+
+        // Validate results
+        assertEquals(expectedPosts, result);
+        verify(mockPostDB).getAllPosts();
+        verify(mockPresenter).prepareSuccessView(expectedOutputData);
+    }
+
+    @Test
+    void GetPostsByCategorySuccessTest() throws Exception {
+        String category = "General";
+        String entryID1 = "123";
+        String entryID2 = "456";
+        String author = "Author1";
+        String contentBody = "Content of post.";
+        String attachmentPath = "path/to/attachment";
+        String fileType = "text/plain";
+        String title = "Post 1";
+        LocalDateTime postedDate = LocalDateTime.now().withNano(0);
+        LocalDateTime lastModified = LocalDateTime.now().withNano(0);
+        int likes = 5;
+        int dislikes = 2;
+        List<Comment> comments = new ArrayList<>();
+
+        // JSON responses from mock database
+        JSONObject postJSON1 = new JSONObject();
+        postJSON1.put("post_id", entryID1);
+        postJSON1.put("author", author);
+        postJSON1.put("content_body", contentBody);
+        postJSON1.put("attachment_path", attachmentPath);
+        postJSON1.put("file_type", fileType);
+        postJSON1.put("title", title);
+        postJSON1.put("category", category);
+        postJSON1.put("posted_date", postedDate.toString());
+        postJSON1.put("last_modified", lastModified.toString());
+        postJSON1.put("likes", likes);
+        postJSON1.put("dislikes", dislikes);
+        postJSON1.put("comments", new JSONArray());
+
+        JSONObject postJSON2 = new JSONObject(convertJsonToMap(postJSON1));
+        postJSON2.put("post_id", entryID2); // Different ID for the second post
+
+        List<JSONObject> postList = new ArrayList<>();
+        postList.add(postJSON1);
+        postList.add(postJSON2);
+
+        when(mockPostDB.getPostsByCategory(category)).thenReturn(postList);
+
+        // Define expected outputs
+        Content expectedContent1 = new PostContent(contentBody, attachmentPath, fileType);
+        Content expectedContent2 = new PostContent(contentBody, attachmentPath, fileType);
+
+        Post expectedPost1 = new Post(entryID1, author, expectedContent1, postedDate, lastModified, likes, dislikes, title, comments, category);
+        Post expectedPost2 = new Post(entryID2, author, expectedContent2, postedDate, lastModified, likes, dislikes, title, comments, category);
+
+        List<Post> expectedPosts = new ArrayList<>();
+        expectedPosts.add(expectedPost1);
+        expectedPosts.add(expectedPost2);
+
+        GetPostOutputData expectedOutputData = new GetPostOutputData(expectedPosts);
+
+        // Call the interactor
+        List<Post> result = interactor.getPostsByCategory(category);
+
+        // Validate results
+        assertEquals(expectedPosts, result);
+        verify(mockPostDB).getPostsByCategory(category);
+        verify(mockPresenter).prepareSuccessView(expectedOutputData);
+    }
+
+    @Test
+    void SwitchToPostViewTest() {
+        // Call the method
+        interactor.switchToPostView();
+
+        // Verify that the presenter was called with switchToPostView
+        verify(mockPresenter).switchToPostView();
+    }
+
+    @Test
+    void SwitchToHomePageViewTest() {
+        // Call the method
+        interactor.switchToHomePageView();
+
+        // Verify that the presenter was called with switchToHomePageView
+        verify(mockPresenter).switchToHomePageView();
+    }
+
+    // Utility method to convert JSONObject to Map
+    private Map<String, Object> convertJsonToMap(JSONObject jsonObject) throws JSONException {
+        Map<String, Object> map = new HashMap<>();
+        Iterator<String> keys = jsonObject.keys();
+
+        while (keys.hasNext()) {
+            String key = keys.next();
+            map.put(key, jsonObject.get(key));
+        }
+
+        return map;
     }
 
 }

--- a/src/test/java/use_case/getpost/GetPostInteractorTest.java
+++ b/src/test/java/use_case/getpost/GetPostInteractorTest.java
@@ -96,7 +96,7 @@ class GetPostInteractorTest {
     @Test
     void GetPostInvalidInputTest() {
         GetPostInputData inputData = new GetPostInputData(null);
-        String expectedErrorMessage = "Unable to retrieve post with entryID: null";
+        String expectedErrorMessage = "Unable to retrieve post with null entryID";
 
         Post result = interactor.getPost(inputData);
 


### PR DESCRIPTION
## Implement Filtering Posts by Category (adding functionality to the Navigation Pane)

This PR implemented the filtering posts by category functionality. Users can now click on one of the filter buttons on the left navigation pane and choose to filter the homepageview to only include posts with a specific `category` tag.

### Major changes

- Addition of a `getPostsByCategory` method to the GetPosts Interactor
- Additional tests to cover the `getPostsByCategory` method

#### Additional changes

- Following feedback from Professor Gries, the exception handling/throwing of the `getPosts `method in the interactor has been updated (see the [related Piazza discussion](https://piazza.com/class/m0b6ljczidm1gs/post/1301))

**Jira Reference:** [FOR-36](https://cscgroup76.atlassian.net/jira/software/projects/FOR/boards/3?selectedIssue=FOR-36)

[FOR-36]: https://cscgroup76.atlassian.net/browse/FOR-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ