### PR TITLE
Enable CORS config for frontend to sent requests to server

### DIFF
--- a/src/main/java/app/AppConfig.java
+++ b/src/main/java/app/AppConfig.java
@@ -3,6 +3,8 @@ package app;
 import org.bson.Document;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import com.mongodb.client.MongoCollection;
 
@@ -24,6 +26,7 @@ import daos.DBUserDataAccessObject;
 import entity.CommonUserFactory;
 import entity.PostFactory;
 import entity.UserFactory;
+import io.github.cdimascio.dotenv.Dotenv;
 import use_case.create_post.CreatePostInputBoundary;
 import use_case.create_post.CreatePostInteractor;
 import use_case.create_post.CreatePostOutputBoundary;
@@ -42,7 +45,15 @@ import use_case.signup.SignupInteractor;
 import use_case.signup.SignupOutputBoundary;
 
 @Configuration
-public class AppConfig {
+public class AppConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(Dotenv.configure().load().get("REACT_APP_BASE_URL"))
+                .allowedMethods("GET", "POST")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
 
     @Bean
     public Repositories repositories() {

--- a/src/main/java/app/ConnectHub.java
+++ b/src/main/java/app/ConnectHub.java
@@ -9,6 +9,7 @@ import org.bson.Document;
 
 import daos.DBPostDataAccessObject;
 import daos.DBUserDataAccessObject;
+import io.github.cdimascio.dotenv.Dotenv;
 import controller.ViewManagerModel;
 import controller.homepage.HomepageViewModel;
 import controller.login.LoginViewModel;
@@ -92,7 +93,7 @@ public class ConnectHub {
 		final HomePageView homepageView = HomepageUseCaseFactory.create(viewManagerModel, homepageViewModel,
 				postViewModel, postDataAccessObject);
 		views.add(homepageView, homepageView.getViewName());
-		
+
 		final PostView postView = GetPostUseCaseFactory.create(viewManagerModel, postViewModel,
 				homepageViewModel, postDataAccessObject);
 		views.add(postView, postView.getViewName());

--- a/src/main/java/app/Repositories.java
+++ b/src/main/java/app/Repositories.java
@@ -27,7 +27,6 @@ public final class Repositories {
         // Connecting to the database
         Dotenv dotenv = Dotenv.configure().load();
 		String connectionString = dotenv.get("MONGO_DB_CONNECTION_STRING");
-        System.out.println(connectionString);
 
 		ServerApi serverApi = ServerApi.builder()
                 .version(ServerApiVersion.V1)


### PR DESCRIPTION
Due to CORS, the backend doesn't respond to the frontend's API requests. This PR configures the server to allows the front end and only the front end to make requests.